### PR TITLE
Zombie Pickaxe Tweak

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -42,6 +42,7 @@
 * [Unstable TNT](tweaks/unstable-tnt.md)
 * [Weakened Bedrock](tweaks/weakened-bedrock.md)
 * [XP Bottling](tweaks/xp-bottling.md)
+* [Zombie Pickaxe](tweaks/zombie-pickaxe.md)
 
 ## Recipes
 

--- a/docs/tweaks/zombie-pickaxe.md
+++ b/docs/tweaks/zombie-pickaxe.md
@@ -1,0 +1,19 @@
+# Zombie Pickaxe
+
+## Description
+
+Chance for zombies to spawn with a pickaxe when below a certain Y level.
+
+## Options
+
+| Name                      | Description                                                  | Type    | Default |
+|---------------------------|--------------------------------------------------------------|---------|---------|
+| enabled                   | Whether this tweak is enabled.                               | boolean | false   |
+| y_level                   | The y level zombies need to spawn for this tweak to trigger. | integer | 50      |
+| chances.none              | The chance for a zombie to not hold a pickaxe.               | integer | 50      |
+| chances.wooden_pickaxe    | The chance for a zombie to hold a wooden pickaxe.            | integer | 20      |
+| chances.stone_pickaxe     | The chance for a zombie to hold a stone pickaxe.             | integer | 10      |
+| chances.iron_pickaxe      | The chance for a zombie to hold a iron pickaxe.              | integer | 5       |
+| chances.golden_pickaxe    | The chance for a zombie to hold a gold pickaxe.              | integer | 5       |
+| chances.diamond_pickaxe   | The chance for a zombie to hold a diamond pickaxe.           | integer | 5       |
+| chances.netherite_pickaxe | The chance for a zombie to hold a netherite pickaxe.         | integer | 5       |

--- a/src/main/kotlin/dev/tarna/moretweaks/api/utils/ChanceUtils.kt
+++ b/src/main/kotlin/dev/tarna/moretweaks/api/utils/ChanceUtils.kt
@@ -2,3 +2,25 @@ package dev.tarna.moretweaks.api.utils
 
 fun chance(percentage: Int) = percentage == 100 || (0..100).random() <= percentage
 fun chance(percentage: Number) = chance(percentage.toInt())
+
+fun <T> weightedChance(vararg chances: Pair<T, Int>): T {
+    val total = chances.sumOf { it.second }
+    val random = (0 until total).random()
+    var current = 0
+    for ((item, chance) in chances) {
+        current += chance
+        if (random < current) return item
+    }
+    return chances.last().first
+}
+
+fun <T> weightedChance(chances: Map<T, Int>): T {
+    val total = chances.values.sum()
+    val random = (0 until total).random()
+    var current = 0
+    for ((item, chance) in chances) {
+        current += chance
+        if (random < current) return item
+    }
+    return chances.entries.last().key
+}

--- a/src/main/kotlin/dev/tarna/moretweaks/config/tweaks/ZombiePickaxeConfig.kt
+++ b/src/main/kotlin/dev/tarna/moretweaks/config/tweaks/ZombiePickaxeConfig.kt
@@ -1,0 +1,16 @@
+package dev.tarna.moretweaks.config.tweaks
+
+import dev.tarna.moretweaks.api.config.options.impl.BooleanOption
+import dev.tarna.moretweaks.api.config.options.impl.IntOption
+
+object ZombiePickaxeConfig {
+    var enabled by BooleanOption("tweaks.zombie_pickaxe.enabled", false)
+    var yLevel by IntOption("tweaks.zombie_pickaxe.y_level", 50)
+    var noneChance by IntOption("tweaks.zombie_pickaxe.chances.none", 50)
+    var woodenPickaxeChance by IntOption("tweaks.zombie_pickaxe.chances.wooden_pickaxe", 20)
+    var stonePickaxeChance by IntOption("tweaks.zombie_pickaxe.chances.stone_pickaxe", 10)
+    var ironPickaxeChance by IntOption("tweaks.zombie_pickaxe.chances.iron_pickaxe", 5)
+    var goldenPickaxeChance by IntOption("tweaks.zombie_pickaxe.chances.golden_pickaxe", 5)
+    var diamondPickaxeChance by IntOption("tweaks.zombie_pickaxe.chances.diamond_pickaxe", 5)
+    var netheritePickaxeChance by IntOption("tweaks.zombie_pickaxe.chances.netherite_pickaxe", 5)
+}

--- a/src/main/kotlin/dev/tarna/moretweaks/tweaks/ZombiePickaxe.kt
+++ b/src/main/kotlin/dev/tarna/moretweaks/tweaks/ZombiePickaxe.kt
@@ -1,0 +1,39 @@
+package dev.tarna.moretweaks.tweaks
+
+import dev.tarna.moretweaks.api.tweaks.Tweak
+import dev.tarna.moretweaks.api.utils.toItemStack
+import dev.tarna.moretweaks.api.utils.weightedChance
+import dev.tarna.moretweaks.config.tweaks.ZombiePickaxeConfig
+import org.bukkit.Material
+import org.bukkit.entity.EntityType
+import org.bukkit.entity.LivingEntity
+import org.bukkit.event.EventHandler
+import org.bukkit.event.entity.EntitySpawnEvent
+
+class ZombiePickaxe : Tweak {
+    override val id = "zombie_pickaxe"
+
+    private lateinit var pickaxeChances: Map<Material, Int>
+
+    override fun reload() {
+        pickaxeChances = mapOf(
+            Material.AIR to ZombiePickaxeConfig.noneChance,
+            Material.WOODEN_PICKAXE to ZombiePickaxeConfig.woodenPickaxeChance,
+            Material.STONE_PICKAXE to ZombiePickaxeConfig.stonePickaxeChance,
+            Material.IRON_PICKAXE to ZombiePickaxeConfig.ironPickaxeChance,
+            Material.GOLDEN_PICKAXE to ZombiePickaxeConfig.goldenPickaxeChance,
+            Material.DIAMOND_PICKAXE to ZombiePickaxeConfig.diamondPickaxeChance,
+            Material.NETHERITE_PICKAXE to ZombiePickaxeConfig.netheritePickaxeChance
+        )
+    }
+
+    @EventHandler
+    fun onZombieSpawn(event: EntitySpawnEvent) {
+        val entity = event.entity as? LivingEntity ?: return
+        if (entity.type != EntityType.ZOMBIE) return
+        if (entity.location.y > ZombiePickaxeConfig.yLevel) return
+        val pickaxe = weightedChance(pickaxeChances)
+        if (pickaxe == Material.AIR) return
+        entity.equipment?.setItemInMainHand(pickaxe.toItemStack())
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -219,6 +219,17 @@ tweaks:
   xp_bottling:
     enabled: false
     xp_per_bottle: 100
+  zombie_pickaxe:
+    enabled: false
+    y_level: 50
+    chances:
+      none: 50
+      wooden_pickaxe: 20
+      stone_pickaxe: 10
+      iron_pickaxe: 5
+      golden_pickaxe: 5
+      diamond_pickaxe: 5
+      netherite_pickaxe: 5
 
 recipes:
   blasted_ore_blocks:

--- a/src/main/resources/lang/en.yml
+++ b/src/main/resources/lang/en.yml
@@ -110,6 +110,9 @@ tweak:
   xp_bottling:
     name: "XP Bottling"
     description: "Bottle your experience points into bottles of enchanting to store them."
+  zombie_pickaxe:
+    name: "Zombie Pickaxe"
+    description: "Chance for zombies to spawn with a pickaxe when below a certain Y level."
 
 recipe:
   blasted_ore_blocks:


### PR DESCRIPTION
A chance for zombies to hold a pickaxe when they spawn below a certain y-level. The original idea can be found [here](https://www.reddit.com/r/minecraftsuggestions/comments/cxtxr9/zombies_below_y50_should_have_a_fairly_common).