### PR TITLE
Wither Flesh Tweak

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -41,6 +41,7 @@
 * [Unlock All Recipes](tweaks/unlock-all-recipes.md)
 * [Unstable TNT](tweaks/unstable-tnt.md)
 * [Weakened Bedrock](tweaks/weakened-bedrock.md)
+* [Wither Flesh](tweaks/wither-flesh.md)
 * [XP Bottling](tweaks/xp-bottling.md)
 
 ## Recipes

--- a/docs/tweaks/wither-flesh.md
+++ b/docs/tweaks/wither-flesh.md
@@ -1,0 +1,13 @@
+# Wither Flesh
+
+## Description
+
+Mobs drop rotten flesh when killed by a wither.
+
+## Options
+
+| Name    | Description                           | Type    | Default |
+|---------|---------------------------------------|---------|---------|
+| enabled | Whether this tweak is enabled.        | boolean | false   |
+| chance  | The chance for this tweak to trigger. | integer | 100     |
+| amount  | The amount of rotten flesh to drop.   | integer | 1       |

--- a/src/main/kotlin/dev/tarna/moretweaks/api/utils/LocationUtils.kt
+++ b/src/main/kotlin/dev/tarna/moretweaks/api/utils/LocationUtils.kt
@@ -1,0 +1,8 @@
+package dev.tarna.moretweaks.api.utils
+
+import org.bukkit.Location
+import org.bukkit.inventory.ItemStack
+
+fun Location.dropItemWithoutVelocity(item: ItemStack) {
+    world.dropItemWithoutVelocity(this, item)
+}

--- a/src/main/kotlin/dev/tarna/moretweaks/config/tweaks/WitherFleshConfig.kt
+++ b/src/main/kotlin/dev/tarna/moretweaks/config/tweaks/WitherFleshConfig.kt
@@ -1,0 +1,10 @@
+package dev.tarna.moretweaks.config.tweaks
+
+import dev.tarna.moretweaks.api.config.options.impl.BooleanOption
+import dev.tarna.moretweaks.api.config.options.impl.IntOption
+
+object WitherFleshConfig {
+    var enabled by BooleanOption("tweaks.wither_flesh.enabled", false)
+    var chance by IntOption("tweaks.wither_flesh.chance", 100)
+    var amount by IntOption("tweaks.wither_flesh.amount", 1)
+}

--- a/src/main/kotlin/dev/tarna/moretweaks/tweaks/WitherFlesh.kt
+++ b/src/main/kotlin/dev/tarna/moretweaks/tweaks/WitherFlesh.kt
@@ -1,0 +1,53 @@
+package dev.tarna.moretweaks.tweaks
+
+import dev.tarna.moretweaks.api.tweaks.Tweak
+import dev.tarna.moretweaks.api.utils.chance
+import dev.tarna.moretweaks.api.utils.not
+import dev.tarna.moretweaks.api.utils.toItemStack
+import dev.tarna.moretweaks.config.tweaks.WitherFleshConfig
+import org.bukkit.Bukkit
+import org.bukkit.Material
+import org.bukkit.entity.EntityType
+import org.bukkit.entity.Projectile
+import org.bukkit.event.EventHandler
+import org.bukkit.event.entity.EntityDamageByEntityEvent
+import org.bukkit.event.entity.EntityDamageEvent
+import org.bukkit.event.entity.EntityDeathEvent
+
+class WitherFlesh : Tweak {
+    override val id = "wither_flesh"
+
+    private lateinit var chance: Number
+    private lateinit var amount: Number
+
+    override fun reload() {
+        chance = WitherFleshConfig.chance
+        amount = WitherFleshConfig.amount
+    }
+
+    @EventHandler
+    fun onDeath(event: EntityDeathEvent) {
+        val entity = event.entity
+        val damage = entity.lastDamageCause ?: return
+        if (!killedByWither(damage)) return
+        if (!chance(chance)) return
+
+        event.drops.clear()
+        event.drops.add(Material.ROTTEN_FLESH.toItemStack(amount))
+    }
+
+    private fun killedByWither(event: EntityDamageEvent): Boolean {
+        return when {
+            event.cause == EntityDamageEvent.DamageCause.WITHER -> true
+            event.cause == EntityDamageEvent.DamageCause.PROJECTILE && event is EntityDamageByEntityEvent -> {
+                val projectile = event.damager as Projectile? ?: return false
+                projectile.type == EntityType.WITHER_SKULL
+            }
+            event.cause == EntityDamageEvent.DamageCause.ENTITY_EXPLOSION && event is EntityDamageByEntityEvent -> {
+                val entity = event.damager
+                entity.type == EntityType.WITHER || entity.type == EntityType.WITHER_SKULL
+            }
+            else -> false
+        }
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -216,6 +216,10 @@ tweaks:
       - "world"
       - "world_nether"
       - "world_the_end"
+  wither_flesh:
+    enabled: false
+    chance: 100
+    amount: 1
   xp_bottling:
     enabled: false
     xp_per_bottle: 100

--- a/src/main/resources/lang/en.yml
+++ b/src/main/resources/lang/en.yml
@@ -107,6 +107,9 @@ tweak:
   weakened_bedrock:
     name: "Weakened Bedrock"
     description: "Allow bedrock to be weakened by lingering potion of weakness."
+  wither_flesh:
+    name: "Wither Flesh"
+    description: "Mobs drop rotten flesh when killed by a wither."
   xp_bottling:
     name: "XP Bottling"
     description: "Bottle your experience points into bottles of enchanting to store them."


### PR DESCRIPTION
Mobs drop rotten flesh instead of their normal drop when killed by a wither or the withering effect. The original idea can be found [here](https://www.reddit.com/r/minecraftsuggestions/comments/lbsw3d/if_an_animal_dies_due_to_the_wither_effect_it/).